### PR TITLE
Support .mp4 video extensions

### DIFF
--- a/mpl.js
+++ b/mpl.js
@@ -687,7 +687,7 @@ onload = function() {
       if (protocol === null) {
         // Call on original handler
         mediaManager['onLoadOrig'](event); // Call on the original callback
-      }else{
+      } else {
         console.log('### Media Protocol Identified as ' + ext);
         setDebugMessage('mediaProtocol', ext);
 

--- a/mpl.js
+++ b/mpl.js
@@ -683,13 +683,14 @@ onload = function() {
         protocol = cast.player.api.CreateSmoothStreamingProtocol(mediaHost);
         ext = 'Smooth Streaming';
       }
-      
+
       if (protocol === null) {
         // Call on original handler
         mediaManager['onLoadOrig'](event); // Call on the original callback
       }else{
         console.log('### Media Protocol Identified as ' + ext);
         setDebugMessage('mediaProtocol', ext);
+
         // Advanced Playback - HLS, MPEG DASH, SMOOTH STREAMING
         // Player registers to listen to the media element events through the
         // mediaHost property of the  mediaElement

--- a/mpl.js
+++ b/mpl.js
@@ -683,18 +683,23 @@ onload = function() {
         protocol = cast.player.api.CreateSmoothStreamingProtocol(mediaHost);
         ext = 'Smooth Streaming';
       }
-      console.log('### Media Protocol Identified as ' + ext);
-      setDebugMessage('mediaProtocol', ext);
-
-      // Advanced Playback - HLS, MPEG DASH, SMOOTH STREAMING
-      // Player registers to listen to the media element events through the
-      // mediaHost property of the  mediaElement
-      mediaPlayer = new cast.player.api.Player(mediaHost);
-      if (liveStreaming) {
-        mediaPlayer.load(protocol, Infinity);
-      }
-      else {
-        mediaPlayer.load(protocol, initialTimeIndexSeconds);
+      
+      if (protocol === null) {
+        // Call on original handler
+        mediaManager['onLoadOrig'](event); // Call on the original callback
+      }else{
+        console.log('### Media Protocol Identified as ' + ext);
+        setDebugMessage('mediaProtocol', ext);
+        // Advanced Playback - HLS, MPEG DASH, SMOOTH STREAMING
+        // Player registers to listen to the media element events through the
+        // mediaHost property of the  mediaElement
+        mediaPlayer = new cast.player.api.Player(mediaHost);
+        if (liveStreaming) {
+          mediaPlayer.load(protocol, Infinity);
+        }
+        else {
+          mediaPlayer.load(protocol, initialTimeIndexSeconds);
+        }
       }
       setDebugMessage('mediaHostState', 'success');
     }


### PR DESCRIPTION
Call original handler for video sources with any extension other than .m3u8, .mpd, .ism
This change allows using the custom receiver for all video types.